### PR TITLE
Update PusherSwiftWithEncryption to 10.1.5

### DIFF
--- a/ios/pusher_client_fixed.podspec
+++ b/ios/pusher_client_fixed.podspec
@@ -19,7 +19,7 @@ A pusher client fixed plugin that works.
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'PusherSwiftWithEncryption', '~> 8.0.0'
+  s.dependency 'PusherSwiftWithEncryption', '10.1.5'
   s.platform = :ios, '9.0'
 
   # Flutter.framework does not contain a i386 slice.


### PR DESCRIPTION
to avoid failing build on iOS simulator